### PR TITLE
Add global chore log view

### DIFF
--- a/client/all.html
+++ b/client/all.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>All Chore Logs</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 1rem; }
+    ul { padding-left: 1.5rem; }
+  </style>
+</head>
+<body>
+  <h1>All Chore Logs</h1>
+  <ul id="all-logs"></ul>
+  <a href="index.html">Back</a>
+  <script>
+    const token = localStorage.getItem('token') || '';
+    if (token) {
+      loadAllLogs();
+    } else {
+      document.getElementById('all-logs').innerHTML = '<li>Please log in first</li>';
+    }
+
+    async function loadAllLogs() {
+      const res = await fetch('/api/logs/all', { headers: { 'Authorization': 'Bearer ' + token } });
+      const logs = await res.json();
+      const list = document.getElementById('all-logs');
+      list.innerHTML = '';
+      logs.forEach(l => {
+        const li = document.createElement('li');
+        const date = new Date(l.ts).toLocaleString();
+        li.textContent = `${date}: ${l.user} - ${l.chore}`;
+        list.appendChild(li);
+      });
+    }
+  </script>
+</body>
+</html>

--- a/client/index.html
+++ b/client/index.html
@@ -30,6 +30,7 @@
     <datalist id="chore-suggestions"></datalist>
     <button onclick="logChore()">Add</button>
     <button onclick="logout()">Logout</button>
+    <a href="all.html">View all logs</a>
     <h3>Your logs</h3>
     <ul id="logs"></ul>
   </div>

--- a/server/server.js
+++ b/server/server.js
@@ -98,6 +98,20 @@ app.get('/api/logs', authMiddleware, async (req, res) => {
   res.json(logsWithNames);
 });
 
+app.get('/api/logs/all', authMiddleware, async (req, res) => {
+  await db.read();
+  const logs = db.data.logs.map(l => {
+    const user = db.data.users.find(u => u.id === l.userId);
+    const chore = db.data.chores.find(c => c.id === l.choreId);
+    return {
+      ...l,
+      user: user ? user.username : 'unknown',
+      chore: chore ? chore.name : 'unknown',
+    };
+  });
+  res.json(logs);
+});
+
 app.get('/api/summary', authMiddleware, async (req, res) => {
   const from = parseInt(req.query.from) || 0;
   const to = parseInt(req.query.to) || Date.now();


### PR DESCRIPTION
## Summary
- expose `/api/logs/all` to fetch every user's chores
- link from main page to a new **All Logs** page
- implement new page `all.html` listing chores by user

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68406de8953c8331af265395ca2a321d