### PR TITLE
Document env secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,8 @@ node server/server.js
 ```
 
 The app will be available at `http://localhost:3000`.
+
+## Environment variables
+
+`SECRET` sets the token signing secret for the server. If not provided, the
+default `"replace-this-secret"` is used.

--- a/server/server.js
+++ b/server/server.js
@@ -26,7 +26,9 @@ async function initDB() {
 }
 initDB();
 
-const SECRET = 'replace-this-secret';
+// Secret used for signing JWT tokens. Can be overridden by the SECRET
+// environment variable.
+const SECRET = process.env.SECRET || 'replace-this-secret';
 
 function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization || '';


### PR DESCRIPTION
## Summary
- let the server secret be overridden by `SECRET` env var
- document the `SECRET` variable in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684073c641a08331ae691bf168a474b3