### PR TITLE
Implement token expiry and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ node server/server.js
 ```
 
 The app will be available at `http://localhost:3000`.
+
+Authentication tokens expire after **1 day**, so you'll need to log in again once a token has expired.

--- a/server/server.js
+++ b/server/server.js
@@ -37,6 +37,9 @@ function authMiddleware(req, res, next) {
     req.user = payload;
     next();
   } catch (err) {
+    if (err.name === 'TokenExpiredError') {
+      return res.status(401).json({ error: 'Token expired' });
+    }
     return res.status(401).json({ error: 'Invalid token' });
   }
 }
@@ -62,7 +65,11 @@ app.post('/api/login', async (req, res) => {
   if (!user) return res.status(400).json({ error: 'Invalid credentials' });
   const ok = await bcrypt.compare(password, user.password);
   if (!ok) return res.status(400).json({ error: 'Invalid credentials' });
-  const token = jwt.sign({ id: user.id, username: user.username }, SECRET);
+  const token = jwt.sign(
+    { id: user.id, username: user.username },
+    SECRET,
+    { expiresIn: '1d' }
+  );
   res.json({ token });
 });
 


### PR DESCRIPTION
## Summary
- set token lifetime when calling `jwt.sign`
- handle token expiration in auth middleware
- document token lifetime in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684073fa8f5c8331b328a7654756b82c