### PR TITLE
Add Docker instructions and persist database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --production
+COPY . .
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -21,3 +21,30 @@ node server/server.js
 ```
 
 The app will be available at `http://localhost:3000`.
+
+## Docker
+
+You can also run the app in a container. Build the image:
+
+```bash
+docker build -t choreapp .
+```
+
+Start the container and mount a host file to persist the database:
+
+```bash
+docker run -p 3000:3000 \
+  -v $(pwd)/db.json:/app/server/db.json \
+  choreapp
+```
+
+The server uses `/app/server/db.json` by default. You can specify a different
+location inside the container with the `DB_FILE` environment variable. Adjust
+the mounted path accordingly:
+
+```bash
+docker run -p 3000:3000 \
+  -e DB_FILE=/app/data/mydb.json \
+  -v $(pwd)/mydb.json:/app/data/mydb.json \
+  choreapp
+```

--- a/server/server.js
+++ b/server/server.js
@@ -15,7 +15,7 @@ const app = express();
 app.use(express.json());
 app.use(morgan('dev'));
 
-const dbFile = path.join(__dirname, 'db.json');
+const dbFile = process.env.DB_FILE || path.join(__dirname, 'db.json');
 const adapter = new JSONFile(dbFile);
 const db = new Low(adapter, { users: [], chores: [], logs: [] });
 


### PR DESCRIPTION
## Summary
- allow `server.js` to load DB path from `DB_FILE` environment variable
- add Dockerfile for containerized usage
- document Docker usage including mounting a host file for `db.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684073fb0e3c8331a14a0b317248bbb4