### PR TITLE
Add week navigation to overview

### DIFF
--- a/client/week.html
+++ b/client/week.html
@@ -21,11 +21,17 @@
 <body class="font-sans bg-p564 min-h-screen p-4">
   <div id="wrapper" class="max-w-xl mx-auto p-4 bg-white rounded shadow overflow-x-auto">
     <h1 class="text-2xl font-bold mb-2">Weekly Overview</h1>
+    <div class="flex items-center justify-between mb-4">
+      <button id="prev-week" class="px-2 py-1 bg-gray-200 rounded">&lt;</button>
+      <div id="week-info" class="font-semibold"></div>
+      <button id="next-week" class="px-2 py-1 bg-gray-200 rounded">&gt;</button>
+    </div>
     <div id="content" class="mb-2">Loading...</div>
     <a href="index.html" class="bg-p604 text-black rounded px-3 py-1 no-underline">Back</a>
   </div>
   <script>
     const token = localStorage.getItem('token') || '';
+    let weekOffset = 0;
     if (token) {
       loadWeek();
     } else {
@@ -41,10 +47,27 @@
       return d;
     }
 
+    function isoWeekNumber(date) {
+      const d = new Date(date);
+      d.setHours(0, 0, 0, 0);
+      d.setDate(d.getDate() + 3 - ((d.getDay() + 6) % 7));
+      const week1 = new Date(d.getFullYear(), 0, 4);
+      return 1 + Math.round(((d - week1) / 86400000 - 3 + ((week1.getDay() + 6) % 7)) / 7);
+    }
+
+    document.getElementById('prev-week').addEventListener('click', () => { weekOffset--; loadWeek(); });
+    document.getElementById('next-week').addEventListener('click', () => { weekOffset++; loadWeek(); });
+
     async function loadWeek() {
       const res = await fetch('/api/logs/all', { headers: { 'Authorization': 'Bearer ' + token } });
       const logs = await res.json();
-      const start = startOfWeek(Date.now());
+      const start = startOfWeek(Date.now() + weekOffset * 7 * 86400000);
+      const weekNum = isoWeekNumber(start);
+      const end = new Date(start);
+      end.setDate(start.getDate() + 6);
+      const weekInfo = document.getElementById('week-info');
+      weekInfo.textContent = `Week ${weekNum} (${start.toLocaleDateString()} - ${end.toLocaleDateString()})`;
+      weekInfo.className = 'font-semibold' + (weekOffset === 0 ? ' bg-p604 px-2 rounded' : '');
       const days = [];
       for (let i = 0; i < 7; i++) {
         const d = new Date(start);


### PR DESCRIPTION
## Summary
- show current week number and range on week overview page
- add next/previous controls to browse weeks
- highlight the current week

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840c9b806348331a4e5efa0746a6eef