### PR TITLE
Add week navigation to index page

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -81,18 +81,41 @@
       const [chores, setChores] = useState([]);
       const [assignments, setAssignments] = useState([]);
       const [suggestions, setSuggestions] = useState([]);
+      const [weekOffset, setWeekOffset] = useState(0);
       const weekdays = ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday'];
 
-      useEffect(() => { loadData(); }, []);
+      function startOfWeek(date) {
+        const d = new Date(date);
+        const day = d.getDay();
+        const diff = (day + 6) % 7;
+        d.setHours(0,0,0,0);
+        d.setDate(d.getDate() - diff);
+        return d;
+      }
+
+      function isoWeekNumber(date) {
+        const d = new Date(date);
+        d.setHours(0, 0, 0, 0);
+        d.setDate(d.getDate() + 3 - ((d.getDay() + 6) % 7));
+        const week1 = new Date(d.getFullYear(), 0, 4);
+        return 1 + Math.round(((d - week1) / 86400000 - 3 + ((week1.getDay() + 6) % 7)) / 7);
+      }
+
+      useEffect(() => { loadData(); }, [weekOffset]);
 
       async function loadData() {
         const res = await fetch('/api/logs/all', { headers: { 'Authorization': 'Bearer ' + token } });
         const logs = await res.json();
+        const start = startOfWeek(Date.now() + weekOffset * 7 * 86400000);
+        const end = new Date(start);
+        end.setDate(start.getDate() + 7);
         const chSet = new Set();
         const map = {};
         logs.forEach(l => {
+          const ts = new Date(l.ts);
+          if (ts < start || ts >= end) return;
           chSet.add(l.chore);
-          const day = new Date(l.ts).toLocaleDateString('en-US', { weekday: 'long' });
+          const day = ts.toLocaleDateString('en-US', { weekday: 'long' });
           const key = l.chore + '|' + day;
           if (!map[key]) {
             map[key] = { choreId: l.chore, day, users: [] };
@@ -130,6 +153,12 @@
         return a ? a.users : [];
       };
 
+      const start = startOfWeek(Date.now() + weekOffset * 7 * 86400000);
+      const weekNum = isoWeekNumber(start);
+      const end = new Date(start);
+      end.setDate(start.getDate() + 6);
+      const weekLabel = `Week ${weekNum} (${start.toLocaleDateString()} - ${end.toLocaleDateString()})`;
+
       return (
         <div className="p-6 max-w-7xl mx-auto">
           <div className="mb-6 bg-white rounded shadow p-4">
@@ -153,6 +182,11 @@
 
           <div className="bg-white rounded shadow p-4 overflow-x-auto">
             <h3 className="text-lg font-bold text-pantone564 mb-3">Weekly Overview</h3>
+            <div className="flex items-center justify-between mb-3">
+              <button onClick={() => setWeekOffset(weekOffset - 1)} className="px-2 py-1 bg-gray-200 rounded">&lt;</button>
+              <div className={"font-semibold" + (weekOffset === 0 ? " bg-pantone604 px-2 rounded" : "")}>{weekLabel}</div>
+              <button onClick={() => setWeekOffset(weekOffset + 1)} className="px-2 py-1 bg-gray-200 rounded">&gt;</button>
+            </div>
             <div className="grid grid-cols-8 gap-2 min-w-[800px]">
               <div className="font-semibold p-3 text-center">Chores</div>
               {weekdays.map(day => (


### PR DESCRIPTION
## Summary
- add week navigation and info to main index page
- filter chore logs by selected week

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840cacbf84c8331893490438b3901b4