### PR TITLE
Add log deletion feature

### DIFF
--- a/client/all.html
+++ b/client/all.html
@@ -58,7 +58,20 @@
         grouped[chore].forEach(l => {
           const il = document.createElement('li');
           const date = new Date(l.ts).toLocaleString();
-          il.textContent = `${date}: ${l.user}`;
+          const span = document.createElement('span');
+          span.textContent = `${date}: ${l.user} `;
+          il.appendChild(span);
+          const btn = document.createElement('button');
+          btn.textContent = 'Remove';
+          btn.className = 'ml-1 text-red-600 underline';
+          btn.addEventListener('click', async () => {
+            await fetch(`/api/logs/${l.id}`, {
+              method: 'DELETE',
+              headers: { 'Authorization': 'Bearer ' + token }
+            });
+            loadAllLogs();
+          });
+          il.appendChild(btn);
           inner.appendChild(il);
         });
         li.appendChild(inner);

--- a/server/server.js
+++ b/server/server.js
@@ -121,6 +121,18 @@ app.get('/api/logs/all', authMiddleware, async (req, res) => {
   res.json(logs);
 });
 
+app.delete('/api/logs/:id', authMiddleware, async (req, res) => {
+  const { id } = req.params;
+  await db.read();
+  const index = db.data.logs.findIndex(l => l.id === id && l.userId === req.user.id);
+  if (index === -1) {
+    return res.status(404).json({ error: 'Log not found' });
+  }
+  db.data.logs.splice(index, 1);
+  await db.write();
+  res.json({ message: 'Deleted' });
+});
+
 app.get('/api/summary', authMiddleware, async (req, res) => {
   const from = parseInt(req.query.from) || 0;
   const to = parseInt(req.query.to) || Date.now();


### PR DESCRIPTION
## Summary
- delete log entries on the server with `DELETE /api/logs/:id`
- show a remove button for each entry in **all.html**

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840cc525ec48331b07f690d450dc624