### PR TITLE
Fix deletion of other users' chore logs

### DIFF
--- a/client/all.html
+++ b/client/all.html
@@ -29,7 +29,9 @@
   </div>
   <script>
     const token = localStorage.getItem('token') || '';
+    let username = '';
     if (token) {
+      username = JSON.parse(atob(token.split('.')[1])).username;
       loadAllLogs();
     } else {
       document.getElementById('all-logs').innerHTML = '<li>Please log in first</li>';
@@ -59,14 +61,18 @@
           const il = document.createElement('li');
           const date = new Date(l.ts).toLocaleString();
           il.textContent = `${date}: ${l.user}`;
-          il.className = 'cursor-pointer hover:line-through';
-          il.addEventListener('click', async () => {
-            await fetch(`/api/logs/${l.id}`, {
-              method: 'DELETE',
-              headers: { 'Authorization': 'Bearer ' + token }
+          if (l.user === username) {
+            il.className = 'cursor-pointer hover:line-through';
+            il.addEventListener('click', async () => {
+              await fetch(`/api/logs/${l.id}`, {
+                method: 'DELETE',
+                headers: { 'Authorization': 'Bearer ' + token }
+              });
+              loadAllLogs();
             });
-            loadAllLogs();
-          });
+          } else {
+            il.className = 'text-gray-500';
+          }
           inner.appendChild(il);
         });
         li.appendChild(inner);

--- a/client/index.html
+++ b/client/index.html
@@ -83,6 +83,7 @@
       const [suggestions, setSuggestions] = useState([]);
       const [weekOffset, setWeekOffset] = useState(0);
       const weekdays = ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday'];
+      const username = JSON.parse(atob(token.split('.')[1])).username;
 
       function startOfWeek(date) {
         const d = new Date(date);
@@ -122,7 +123,7 @@
           }
           const abbrev = l.user.slice(0,3);
           if (!map[key].entries.find(e => e.user === abbrev)) {
-            map[key].entries.push({ user: abbrev, id: l.id });
+            map[key].entries.push({ user: abbrev, id: l.id, own: l.user === username });
           }
         });
         setChores(Array.from(chSet));
@@ -212,8 +213,13 @@
                         {getUsersForChoreAndDay(chore, day).map(entry => (
                           <span
                             key={entry.id}
-                            onClick={() => deleteLog(entry.id)}
-                            className="cursor-pointer bg-pantone564 text-white text-xs px-1 rounded hover:line-through"
+                            onClick={() => entry.own && deleteLog(entry.id)}
+                            className={
+                              (entry.own
+                                ? 'cursor-pointer bg-pantone564 text-white hover:line-through'
+                                : 'bg-gray-300 text-gray-600') +
+                              ' text-xs px-1 rounded'
+                            }
                           >
                             {entry.user}
                           </span>


### PR DESCRIPTION
## Summary
- prevent deleting other users' chore logs on both overview pages
- show other users' logs in gray and non-clickable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840d14c30988331bbe31f8136920995