### PR TITLE
Add weekday selection for chore logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 A multi-user chore logging application with a Node.js backend and a frontend built with React. The UI uses [Tailwind CSS](https://tailwindcss.com/) themed with colors inspired by Pantone 564 and Pantone 604.
 
 The main `index.html` page now renders a React based chore tracker. The chore entry
-field supports autocomplete so you can reuse existing chore names quickly.
+field supports autocomplete so you can reuse existing chore names quickly. You can
+also choose the weekday before adding a chore so it is logged for that day.
 
 You can log out at any time using the **Logout** button in the app.
 

--- a/client/index.html
+++ b/client/index.html
@@ -83,6 +83,7 @@
       const [suggestions, setSuggestions] = useState([]);
       const [weekOffset, setWeekOffset] = useState(0);
       const weekdays = ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday'];
+      const [selectedDay, setSelectedDay] = useState(weekdays[(new Date().getDay() + 6) % 7]);
       const username = JSON.parse(atob(token.split('.')[1])).username;
 
       function startOfWeek(date) {
@@ -132,13 +133,17 @@
 
       async function addChore() {
         if (!newChore.trim()) return;
+        const dayIndex = weekdays.indexOf(selectedDay);
+        const start = startOfWeek(Date.now() + weekOffset * 7 * 86400000);
+        const tsDate = new Date(start);
+        tsDate.setDate(start.getDate() + (dayIndex >= 0 ? dayIndex : 0));
         await fetch('/api/chores', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
             'Authorization': 'Bearer ' + token
           },
-          body: JSON.stringify({ name: newChore.trim() })
+          body: JSON.stringify({ name: newChore.trim(), ts: tsDate.getTime() })
         });
         setNewChore('');
         loadData();
@@ -186,6 +191,15 @@
               <datalist id="chore-suggestions">
                 {suggestions.map(name => <option key={name} value={name} />)}
               </datalist>
+              <select
+                value={selectedDay}
+                onChange={e => setSelectedDay(e.target.value)}
+                className="border p-2 rounded"
+              >
+                {weekdays.map(day => (
+                  <option key={day} value={day}>{day}</option>
+                ))}
+              </select>
               <button className="bg-pantone564 hover:bg-pantone564/90 text-white px-3 py-2 rounded" onClick={addChore}>Add</button>
               <a href="all.html" className="bg-gray-300 hover:bg-gray-400 text-black px-3 py-2 rounded no-underline">All Logs</a>
               <button className="bg-gray-300 hover:bg-gray-400 text-black px-3 py-2 rounded" onClick={onLogout}>Logout</button>

--- a/server/server.js
+++ b/server/server.js
@@ -83,7 +83,7 @@ app.get('/api/chores/autocomplete', authMiddleware, async (req, res) => {
 });
 
 app.post('/api/chores', authMiddleware, async (req, res) => {
-  const { name } = req.body;
+  const { name, ts } = req.body;
   if (!name) return res.status(400).json({ error: 'Missing chore name' });
   await db.read();
   let chore = db.data.chores.find(c => c.name.toLowerCase() === name.toLowerCase());
@@ -91,7 +91,8 @@ app.post('/api/chores', authMiddleware, async (req, res) => {
     chore = { id: uuidv4(), name };
     db.data.chores.push(chore);
   }
-  const log = { id: uuidv4(), userId: req.user.id, choreId: chore.id, ts: Date.now() };
+  const timestamp = Number.isFinite(Number(ts)) ? Number(ts) : Date.now();
+  const log = { id: uuidv4(), userId: req.user.id, choreId: chore.id, ts: timestamp };
   db.data.logs.push(log);
   await db.write();
   res.json({ message: 'Logged', log });


### PR DESCRIPTION
## Summary
- log chores for a chosen weekday instead of always for today
- update React UI to pick a weekday before adding a chore
- document weekday selection in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840d334963083319b75d2d9f409f100