### PR TITLE
Add weekday buttons for chore selection

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -83,7 +83,7 @@
       const [suggestions, setSuggestions] = useState([]);
       const [weekOffset, setWeekOffset] = useState(0);
       const weekdays = ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday'];
-      const [selectedDay, setSelectedDay] = useState(weekdays[(new Date().getDay() + 6) % 7]);
+      const [selectedDay, setSelectedDay] = useState('');
       const username = JSON.parse(atob(token.split('.')[1])).username;
 
       function startOfWeek(date) {
@@ -134,6 +134,7 @@
       async function addChore() {
         if (!newChore.trim()) return;
         const dayIndex = weekdays.indexOf(selectedDay);
+        if (dayIndex === -1) return;
         const start = startOfWeek(Date.now() + weekOffset * 7 * 86400000);
         const tsDate = new Date(start);
         tsDate.setDate(start.getDate() + (dayIndex >= 0 ? dayIndex : 0));
@@ -146,6 +147,7 @@
           body: JSON.stringify({ name: newChore.trim(), ts: tsDate.getTime() })
         });
         setNewChore('');
+        setSelectedDay('');
         loadData();
       }
 
@@ -191,15 +193,6 @@
               <datalist id="chore-suggestions">
                 {suggestions.map(name => <option key={name} value={name} />)}
               </datalist>
-              <select
-                value={selectedDay}
-                onChange={e => setSelectedDay(e.target.value)}
-                className="border p-2 rounded"
-              >
-                {weekdays.map(day => (
-                  <option key={day} value={day}>{day}</option>
-                ))}
-              </select>
               <button className="bg-pantone564 hover:bg-pantone564/90 text-white px-3 py-2 rounded" onClick={addChore}>Add</button>
               <a href="all.html" className="bg-gray-300 hover:bg-gray-400 text-black px-3 py-2 rounded no-underline">All Logs</a>
               <button className="bg-gray-300 hover:bg-gray-400 text-black px-3 py-2 rounded" onClick={onLogout}>Logout</button>
@@ -216,7 +209,18 @@
             <div className="grid grid-cols-8 gap-2 min-w-[800px]">
               <div className="font-semibold p-3 text-center">Chores</div>
               {weekdays.map(day => (
-                <div key={day} className="font-semibold p-3 text-center border-b bg-pantone604/30 text-pantone564">{day}</div>
+                <div
+                  key={day}
+                  onClick={() => setSelectedDay(day)}
+                  className={
+                    "font-semibold p-3 text-center border-b cursor-pointer " +
+                    (selectedDay === day
+                      ? "bg-pantone604 text-pantone564"
+                      : "bg-pantone604/30 text-pantone564")
+                  }
+                >
+                  {day}
+                </div>
               ))}
               {chores.map(chore => (
                 <div key={chore} className="contents">


### PR DESCRIPTION
## Summary
- remove dropdown for weekday selection
- enable selecting weekdays from table headers
- reset selected weekday after adding a chore

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840d49fa2448331b4686a3fa477c312