### PR TITLE
Default to today if no weekday selected

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -133,11 +133,14 @@
 
       async function addChore() {
         if (!newChore.trim()) return;
-        const dayIndex = weekdays.indexOf(selectedDay);
-        if (dayIndex === -1) return;
         const start = startOfWeek(Date.now() + weekOffset * 7 * 86400000);
+        let dayIndex = weekdays.indexOf(selectedDay);
+        if (dayIndex === -1) {
+          const todayIndex = (new Date().getDay() + 6) % 7; // make Monday=0
+          dayIndex = todayIndex;
+        }
         const tsDate = new Date(start);
-        tsDate.setDate(start.getDate() + (dayIndex >= 0 ? dayIndex : 0));
+        tsDate.setDate(start.getDate() + dayIndex);
         await fetch('/api/chores', {
           method: 'POST',
           headers: {


### PR DESCRIPTION
## Summary
- let addChore default to today's weekday when no day is selected

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840d5bbb6c08331912e17a578c5d867