### PR TITLE
Add groups feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ There is also a **Week overview** page showing the current week's chores. It
 lists chores in rows with days of the week as columns and displays the first
 three letters of each user's name when they completed a chore on that day.
 
+Chores can be organized into **groups**. When adding a chore you may specify a
+group name. Groups are created automatically and inputs provide autocomplete
+suggestions. Weekly overviews and log pages now group chores under their group
+heading.
+
 All open pages stay in sync thanks to a WebSocket connection. When a chore is
 added or removed in one browser, other connected clients update instantly.
 

--- a/client/all.html
+++ b/client/all.html
@@ -50,41 +50,51 @@
       const logs = await res.json();
       const grouped = {};
       logs.forEach(l => {
-        if (!grouped[l.chore]) {
-          grouped[l.chore] = [];
-        }
-        grouped[l.chore].push(l);
+        const grp = l.group || 'Ungrouped';
+        if (!grouped[grp]) grouped[grp] = {};
+        if (!grouped[grp][l.chore]) grouped[grp][l.chore] = [];
+        grouped[grp][l.chore].push(l);
       });
       const list = document.getElementById('all-logs');
       list.innerHTML = '';
-      Object.keys(grouped).forEach(chore => {
-        const li = document.createElement('li');
-        li.className = 'mb-2';
-        const title = document.createElement('strong');
-        title.textContent = chore;
-        li.appendChild(title);
-        const inner = document.createElement('ul');
-        inner.className = 'list-disc pl-4';
-        grouped[chore].forEach(l => {
-          const il = document.createElement('li');
-          const date = new Date(l.ts).toLocaleString();
-          il.textContent = `${date}: ${l.user}`;
-          if (l.user === username) {
-            il.className = 'cursor-pointer hover:line-through';
-            il.addEventListener('click', async () => {
-              await fetch(`/api/logs/${l.id}`, {
-                method: 'DELETE',
-                headers: { 'Authorization': 'Bearer ' + token }
+      Object.keys(grouped).forEach(grp => {
+        const gLi = document.createElement('li');
+        gLi.className = 'mb-2';
+        const gTitle = document.createElement('strong');
+        gTitle.textContent = grp;
+        gLi.appendChild(gTitle);
+        const chList = document.createElement('ul');
+        chList.className = 'pl-4';
+        Object.keys(grouped[grp]).forEach(chore => {
+          const li = document.createElement('li');
+          const title = document.createElement('strong');
+          title.textContent = chore;
+          li.appendChild(title);
+          const inner = document.createElement('ul');
+          inner.className = 'list-disc pl-4';
+          grouped[grp][chore].forEach(l => {
+            const il = document.createElement('li');
+            const date = new Date(l.ts).toLocaleString();
+            il.textContent = `${date}: ${l.user}`;
+            if (l.user === username) {
+              il.className = 'cursor-pointer hover:line-through';
+              il.addEventListener('click', async () => {
+                await fetch(`/api/logs/${l.id}`, {
+                  method: 'DELETE',
+                  headers: { 'Authorization': 'Bearer ' + token }
+                });
+                loadAllLogs();
               });
-              loadAllLogs();
-            });
-          } else {
-            il.className = 'text-gray-500';
-          }
-          inner.appendChild(il);
+            } else {
+              il.className = 'text-gray-500';
+            }
+            inner.appendChild(il);
+          });
+          li.appendChild(inner);
+          chList.appendChild(li);
         });
-        li.appendChild(inner);
-        list.appendChild(li);
+        gLi.appendChild(chList);
+        list.appendChild(gLi);
       });
     }
   </script>

--- a/client/index.html
+++ b/client/index.html
@@ -78,9 +78,11 @@
 
     function ChoreTracker({ token, onLogout }) {
       const [newChore, setNewChore] = useState('');
+      const [newGroup, setNewGroup] = useState('');
       const [chores, setChores] = useState([]);
       const [assignments, setAssignments] = useState([]);
       const [suggestions, setSuggestions] = useState([]);
+      const [groupSuggestions, setGroupSuggestions] = useState([]);
       const [weekOffset, setWeekOffset] = useState(0);
       const weekdays = ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday'];
       const [selectedDay, setSelectedDay] = useState('');
@@ -123,12 +125,14 @@
         const start = startOfWeek(Date.now() + weekOffset * 7 * 86400000);
         const end = new Date(start);
         end.setDate(start.getDate() + 7);
-        const chSet = new Set();
+        const groups = {};
         const map = {};
         logs.forEach(l => {
           const ts = new Date(l.ts);
           if (ts < start || ts >= end) return;
-          chSet.add(l.chore);
+          const grp = l.group || 'Ungrouped';
+          groups[grp] ||= new Set();
+          groups[grp].add(l.chore);
           const day = ts.toLocaleDateString('en-US', { weekday: 'long' });
           const key = l.chore + '|' + day;
           if (!map[key]) {
@@ -139,7 +143,7 @@
             map[key].entries.push({ user: abbrev, id: l.id, own: l.user === username });
           }
         });
-        setChores(Array.from(chSet));
+        setChores(Object.entries(groups).map(([g, set]) => ({ group: g, chores: Array.from(set) })));
         setAssignments(Object.values(map));
       }
 
@@ -159,9 +163,10 @@
             'Content-Type': 'application/json',
             'Authorization': 'Bearer ' + token
           },
-          body: JSON.stringify({ name: newChore.trim(), ts: tsDate.getTime() })
+          body: JSON.stringify({ name: newChore.trim(), ts: tsDate.getTime(), group: newGroup.trim() })
         });
         setNewChore('');
+        setNewGroup('');
         setSelectedDay('');
         loadData();
       }
@@ -180,6 +185,13 @@
           headers: { 'Authorization': 'Bearer ' + token }
         }).then(r => r.json()).then(setSuggestions);
       }, [newChore]);
+
+      useEffect(() => {
+        if (!newGroup.trim()) { setGroupSuggestions([]); return; }
+        fetch('/api/groups/autocomplete?q=' + encodeURIComponent(newGroup.trim()), {
+          headers: { 'Authorization': 'Bearer ' + token }
+        }).then(r => r.json()).then(setGroupSuggestions);
+      }, [newGroup]);
 
       const getUsersForChoreAndDay = (chore, day) => {
         const a = assignments.find(x => x.choreId === chore && x.day === day);
@@ -207,6 +219,17 @@
               />
               <datalist id="chore-suggestions">
                 {suggestions.map(name => <option key={name} value={name} />)}
+              </datalist>
+              <input
+                list="group-suggestions"
+                className="border p-2 rounded"
+                placeholder="Group"
+                value={newGroup}
+                onChange={e => setNewGroup(e.target.value)}
+                onKeyDown={e => e.key === 'Enter' && addChore()}
+              />
+              <datalist id="group-suggestions">
+                {groupSuggestions.map(name => <option key={name} value={name} />)}
               </datalist>
               <button className="bg-pantone564 hover:bg-pantone564/90 text-white px-3 py-2 rounded" onClick={addChore}>Add</button>
               <a href="all.html" className="bg-gray-300 hover:bg-gray-400 text-black px-3 py-2 rounded no-underline">All Logs</a>
@@ -237,30 +260,35 @@
                   {day}
                 </div>
               ))}
-              {chores.map(chore => (
-                <div key={chore} className="contents">
-                  <div className="font-medium p-3 border-r bg-pantone564/20 flex items-center text-pantone564">{chore}</div>
-                  {weekdays.map(day => (
-                    <div key={chore + '-' + day} className="p-2 border min-h-[80px]">
-                      <div className="flex flex-wrap gap-1">
-                        {getUsersForChoreAndDay(chore, day).map(entry => (
-                          <span
-                            key={entry.id}
-                            onClick={() => entry.own && deleteLog(entry.id)}
-                            className={
-                              (entry.own
-                                ? 'cursor-pointer bg-pantone564 text-white hover:line-through'
-                                : 'bg-gray-300 text-gray-600') +
-                              ' text-xs px-1 rounded'
-                            }
-                          >
-                            {entry.user}
-                          </span>
-                        ))}
-                      </div>
+              {chores.map(group => (
+                <React.Fragment key={group.group}>
+                  <div className="col-span-8 font-semibold bg-pantone564/10 p-2 text-pantone564">{group.group}</div>
+                  {group.chores.map(chore => (
+                    <div key={group.group + '-' + chore} className="contents">
+                      <div className="font-medium p-3 border-r bg-pantone564/20 flex items-center text-pantone564">{chore}</div>
+                      {weekdays.map(day => (
+                        <div key={chore + '-' + day} className="p-2 border min-h-[80px]">
+                          <div className="flex flex-wrap gap-1">
+                            {getUsersForChoreAndDay(chore, day).map(entry => (
+                              <span
+                                key={entry.id}
+                                onClick={() => entry.own && deleteLog(entry.id)}
+                                className={
+                                  (entry.own
+                                    ? 'cursor-pointer bg-pantone564 text-white hover:line-through'
+                                    : 'bg-gray-300 text-gray-600') +
+                                  ' text-xs px-1 rounded'
+                                }
+                              >
+                                {entry.user}
+                              </span>
+                            ))}
+                          </div>
+                        </div>
+                      ))}
                     </div>
                   ))}
-                </div>
+                </React.Fragment>
               ))}
             </div>
           </div>

--- a/client/week.html
+++ b/client/week.html
@@ -82,17 +82,19 @@
         d.setDate(start.getDate() + i);
         days.push(d);
       }
-      const chores = {};
+      const groups = {};
       logs.forEach(l => {
         const ts = new Date(l.ts);
         const dayIndex = Math.floor((ts - start) / 86400000);
         if (dayIndex < 0 || dayIndex > 6) return;
-        if (!chores[l.chore]) {
-          chores[l.chore] = Array.from({length:7}, () => []);
+        const grp = l.group || 'Ungrouped';
+        if (!groups[grp]) groups[grp] = {};
+        if (!groups[grp][l.chore]) {
+          groups[grp][l.chore] = Array.from({length:7}, () => []);
         }
         const abbrev = l.user.slice(0,3);
-        if (!chores[l.chore][dayIndex].includes(abbrev)) {
-          chores[l.chore][dayIndex].push(abbrev);
+        if (!groups[grp][l.chore][dayIndex].includes(abbrev)) {
+          groups[grp][l.chore][dayIndex].push(abbrev);
         }
       });
       const table = document.createElement('table');
@@ -108,19 +110,28 @@
         head.appendChild(th);
       });
       table.appendChild(head);
-      Object.keys(chores).sort().forEach(ch => {
-        const tr = document.createElement('tr');
-        const tdTitle = document.createElement('td');
-        tdTitle.textContent = ch;
-        tdTitle.className = 'border px-1 font-semibold bg-gray-50';
-        tr.appendChild(tdTitle);
-        for (let i=0;i<7;i++) {
-          const td = document.createElement('td');
-          td.textContent = chores[ch][i].join(' ');
-          td.className = 'border px-1';
-          tr.appendChild(td);
-        }
-        table.appendChild(tr);
+      Object.keys(groups).forEach(grp => {
+        const hr = document.createElement('tr');
+        const ht = document.createElement('th');
+        ht.textContent = grp;
+        ht.colSpan = 8;
+        ht.className = 'border bg-p604/50 px-1 text-left';
+        hr.appendChild(ht);
+        table.appendChild(hr);
+        Object.keys(groups[grp]).sort().forEach(ch => {
+          const tr = document.createElement('tr');
+          const tdTitle = document.createElement('td');
+          tdTitle.textContent = ch;
+          tdTitle.className = 'border px-1 font-semibold bg-gray-50';
+          tr.appendChild(tdTitle);
+          for (let i=0;i<7;i++) {
+            const td = document.createElement('td');
+            td.textContent = groups[grp][ch][i].join(' ');
+            td.className = 'border px-1';
+            tr.appendChild(td);
+          }
+          table.appendChild(tr);
+        });
       });
       document.getElementById('content').innerHTML = '';
       document.getElementById('content').appendChild(table);


### PR DESCRIPTION
## Summary
- initialize database with `groups`
- add `POST /api/groups` and `GET /api/groups/autocomplete`
- allow chores to have a `groupId` and create groups on the fly
- display chores grouped by their group name in the UI
- let users pick a group when adding a chore
- update log pages to group chores by group
- document groups feature in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68416201984c83318eacb2a34ffe9513