### PR TITLE
Fix inline Babel error

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -131,7 +131,7 @@
           const ts = new Date(l.ts);
           if (ts < start || ts >= end) return;
           const grp = l.group || 'Ungrouped';
-          groups[grp] ||= new Set();
+          if (!groups[grp]) groups[grp] = new Set();
           groups[grp].add(l.chore);
           const day = ts.toLocaleDateString('en-US', { weekday: 'long' });
           const key = l.chore + '|' + day;

--- a/server/server.js
+++ b/server/server.js
@@ -33,7 +33,9 @@ const db = new Low(adapter, { users: [], chores: [], logs: [], groups: [] });
 
 async function initDB() {
   await db.read();
-  db.data ||= { users: [], chores: [], logs: [], groups: [] };
+  if (!db.data) {
+    db.data = { users: [], chores: [], logs: [], groups: [] };
+  }
   await db.write();
 }
 initDB();
@@ -193,7 +195,7 @@ app.get('/api/summary', authMiddleware, async (req, res) => {
   const filtered = db.data.logs.filter(l => l.ts >= from && l.ts <= to);
   const counts = {};
   for (const log of filtered) {
-    counts[log.userId] ||= 0;
+    if (!counts[log.userId]) counts[log.userId] = 0;
     counts[log.userId]++;
   }
   res.json(counts);


### PR DESCRIPTION
## Summary
- avoid using the `||=` operator in the client and server
- initialize the DB data if undefined

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68416466d4088331ac6aaa0e746e92e0