### PR TITLE
Initialize missing DB arrays

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -35,6 +35,11 @@ async function initDB() {
   await db.read();
   if (!db.data) {
     db.data = { users: [], chores: [], logs: [], groups: [] };
+  } else {
+    if (!Array.isArray(db.data.users)) db.data.users = [];
+    if (!Array.isArray(db.data.chores)) db.data.chores = [];
+    if (!Array.isArray(db.data.logs)) db.data.logs = [];
+    if (!Array.isArray(db.data.groups)) db.data.groups = [];
   }
   await db.write();
 }


### PR DESCRIPTION
## Summary
- handle missing arrays when reading db.json

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841659d9cfc83318bfac712387f7452