### PR TITLE
Show top chores even without logs

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -121,8 +121,12 @@
       useEffect(() => { loadData(); }, [weekOffset]);
 
       async function loadData() {
-        const res = await fetch('/api/logs/all', { headers: { 'Authorization': 'Bearer ' + token } });
-        const logs = await res.json();
+        const [logsRes, topRes] = await Promise.all([
+          fetch('/api/logs/all', { headers: { 'Authorization': 'Bearer ' + token } }),
+          fetch('/api/chores/top', { headers: { 'Authorization': 'Bearer ' + token } })
+        ]);
+        const logs = await logsRes.json();
+        const top = await topRes.json();
         const start = startOfWeek(Date.now() + weekOffset * 7 * 86400000);
         const end = new Date(start);
         end.setDate(start.getDate() + 7);
@@ -141,6 +145,11 @@
           }
           const abbrev = l.user.slice(0,3);
           map[key].entries.push({ user: abbrev, id: l.id, own: l.user === username });
+        });
+        top.forEach(ch => {
+          const grp = ch.group || 'Ungrouped';
+          if (!groups[grp]) groups[grp] = new Set();
+          groups[grp].add(ch.name);
         });
         setChores(Object.entries(groups).map(([g, set]) => ({ group: g, chores: Array.from(set) })));
         setAssignments(Object.values(map));

--- a/client/week.html
+++ b/client/week.html
@@ -67,8 +67,12 @@
     document.getElementById('next-week').addEventListener('click', () => { weekOffset++; loadWeek(); });
 
     async function loadWeek() {
-      const res = await fetch('/api/logs/all', { headers: { 'Authorization': 'Bearer ' + token } });
-      const logs = await res.json();
+      const [logsRes, topRes] = await Promise.all([
+        fetch('/api/logs/all', { headers: { 'Authorization': 'Bearer ' + token } }),
+        fetch('/api/chores/top', { headers: { 'Authorization': 'Bearer ' + token } })
+      ]);
+      const logs = await logsRes.json();
+      const top = await topRes.json();
       const start = startOfWeek(Date.now() + weekOffset * 7 * 86400000);
       const weekNum = isoWeekNumber(start);
       const end = new Date(start);
@@ -94,6 +98,13 @@
         }
         const abbrev = l.user.slice(0,3);
         groups[grp][l.chore][dayIndex].push(abbrev);
+      });
+      top.forEach(ch => {
+        const grp = ch.group || 'Ungrouped';
+        if (!groups[grp]) groups[grp] = {};
+        if (!groups[grp][ch.name]) {
+          groups[grp][ch.name] = Array.from({length:7}, () => []);
+        }
       });
       const table = document.createElement('table');
       table.className = 'border-collapse w-full text-sm';


### PR DESCRIPTION
## Summary
- add `/api/chores/top` endpoint to get the ten most logged chores
- show those chores in the main weekly overview
- ensure top chores also show up on the standalone week page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842130d707c83318b23d1bd1d1b1fc0