### PR TITLE
Improve mobile view with abbreviated weekdays

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ You can log out at any time using the **Logout** button in the app.
 
 There is also a **Week overview** page showing the current week's chores. It
 lists chores in rows with days of the week as columns and displays the first
-three letters of each user's name when they completed a chore on that day.
+three letters of each user's name when they completed a chore on that day. The
+day headers are abbreviated to three letters for a more compact layout on
+mobile screens.
 
 Chores can be organized into **groups**. When adding a chore you may specify a
 group name. Groups are created automatically and inputs provide autocomplete

--- a/client/index.html
+++ b/client/index.html
@@ -84,7 +84,7 @@
       const [suggestions, setSuggestions] = useState([]);
       const [groupSuggestions, setGroupSuggestions] = useState([]);
       const [weekOffset, setWeekOffset] = useState(0);
-      const weekdays = ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday'];
+      const weekdays = ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'];
       const [selectedDay, setSelectedDay] = useState('');
       const [selectedChore, setSelectedChore] = useState({ name: '', group: '' });
       const username = JSON.parse(atob(token.split('.')[1])).username;
@@ -138,7 +138,7 @@
           const grp = l.group || 'Ungrouped';
           if (!groups[grp]) groups[grp] = new Set();
           groups[grp].add(l.chore);
-          const day = ts.toLocaleDateString('en-US', { weekday: 'long' });
+          const day = ts.toLocaleDateString('en-US', { weekday: 'short' });
           const key = grp + '|' + l.chore + '|' + day;
           if (!map[key]) {
             map[key] = { choreId: l.chore, group: grp, day, entries: [] };


### PR DESCRIPTION
## Summary
- abbreviate weekday headers to `Mon/Tue/...` in the React UI
- store short weekday names when loading data
- mention shortened headers in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684294e7fd6c8331bbc7add1ab2b2e59