### PR TITLE
Add sticky weekday headers

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -271,7 +271,7 @@
               <button onClick={() => setWeekOffset(weekOffset + 1)} className="px-2 py-1 bg-gray-200 rounded">&gt;</button>
             </div>
             <div className="grid grid-cols-8 gap-2 min-w-[800px]">
-              <div className="font-semibold p-3 text-center">Chores</div>
+              <div className="font-semibold p-3 text-center sticky top-0 bg-white z-10">Chores</div>
               {weekdays.map(day => (
                 <div
                   key={day}
@@ -283,7 +283,7 @@
                     }
                   }}
                   className={
-                    "font-semibold p-3 text-center border-b cursor-pointer " +
+                    "font-semibold p-3 text-center border-b cursor-pointer sticky top-0 z-10 " +
                     (selectedDay === day
                       ? "bg-pantone604 text-pantone564"
                       : "bg-pantone604/30 text-pantone564")

--- a/client/week.html
+++ b/client/week.html
@@ -110,12 +110,12 @@
       table.className = 'border-collapse w-full text-sm';
       const head = document.createElement('tr');
       const empty = document.createElement('th');
-      empty.className = 'border bg-p604 px-1';
+      empty.className = 'border bg-p604 px-1 sticky top-0 z-10';
       head.appendChild(empty);
       days.forEach(d => {
         const th = document.createElement('th');
         th.textContent = d.toLocaleDateString(undefined, { weekday: 'short' });
-        th.className = 'border bg-p604 px-1';
+        th.className = 'border bg-p604 px-1 sticky top-0 z-10';
         head.appendChild(th);
       });
       table.appendChild(head);


### PR DESCRIPTION
## Summary
- keep weekday headers visible on scroll for weekly overview
- apply sticky style to grid headers on the main page
- make headers sticky in weekly table view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842a6fd14388331841b1b9345bd2217