### PR TITLE
Fix sticky headers

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -21,7 +21,7 @@
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
 </head>
-<body class="bg-gradient-to-br from-pantone604/10 to-pantone564/10 min-h-screen flex items-center justify-center">
+<body class="bg-gradient-to-br from-pantone604/10 to-pantone564/10 min-h-screen">
   <div id="root" class="w-full"></div>
 
   <script type="text/babel">


### PR DESCRIPTION
## Summary
- remove flex-based centering from `index.html` body so sticky day headers remain visible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68474127ac5c83319becc0c676fc6ea7