### PR TITLE
Separate weekday header

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -76,6 +76,34 @@
       );
     }
 
+    function WeekdayHeader({ weekdays, selectedDay, setSelectedDay, selectedChore, quickAdd }) {
+      return (
+        <div className="grid grid-cols-8 gap-2 min-w-[800px]">
+          <div className="font-semibold p-3 text-center sticky top-0 bg-white z-10">Chores</div>
+          {weekdays.map(day => (
+            <div
+              key={day}
+              onClick={() => {
+                if (selectedChore.name) {
+                  quickAdd(selectedChore.name, selectedChore.group, day);
+                } else {
+                  setSelectedDay(day);
+                }
+              }}
+              className={
+                "font-semibold p-3 text-center border-b cursor-pointer sticky top-0 z-10 " +
+                (selectedDay === day
+                  ? "bg-pantone604 text-pantone564"
+                  : "bg-pantone604/30 text-pantone564")
+              }
+            >
+              {day}
+            </div>
+          ))}
+        </div>
+      );
+    }
+
     function ChoreTracker({ token, onLogout }) {
       const [newChore, setNewChore] = useState('');
       const [newGroup, setNewGroup] = useState('');
@@ -270,28 +298,14 @@
               <div className={"font-semibold" + (weekOffset === 0 ? " bg-pantone604 px-2 rounded" : "")}>{weekLabel}</div>
               <button onClick={() => setWeekOffset(weekOffset + 1)} className="px-2 py-1 bg-gray-200 rounded">&gt;</button>
             </div>
+            <WeekdayHeader
+              weekdays={weekdays}
+              selectedDay={selectedDay}
+              setSelectedDay={setSelectedDay}
+              selectedChore={selectedChore}
+              quickAdd={quickAdd}
+            />
             <div className="grid grid-cols-8 gap-2 min-w-[800px]">
-              <div className="font-semibold p-3 text-center sticky top-0 bg-white z-10">Chores</div>
-              {weekdays.map(day => (
-                <div
-                  key={day}
-                  onClick={() => {
-                    if (selectedChore.name) {
-                      quickAdd(selectedChore.name, selectedChore.group, day);
-                    } else {
-                      setSelectedDay(day);
-                    }
-                  }}
-                  className={
-                    "font-semibold p-3 text-center border-b cursor-pointer sticky top-0 z-10 " +
-                    (selectedDay === day
-                      ? "bg-pantone604 text-pantone564"
-                      : "bg-pantone604/30 text-pantone564")
-                  }
-                >
-                  {day}
-                </div>
-              ))}
               {chores.map(group => (
                 <React.Fragment key={group.group}>
                   <div className="col-span-8 font-semibold bg-pantone564/10 p-2 text-pantone564">{group.group}</div>


### PR DESCRIPTION
## Summary
- extract table header into a new `WeekdayHeader` component
- render chore rows below the new header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68482cf617588331b4d3afb82e84b80f