### PR TITLE
Add scrollable chore tables

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -298,17 +298,18 @@
               <div className={"font-semibold" + (weekOffset === 0 ? " bg-pantone604 px-2 rounded" : "")}>{weekLabel}</div>
               <button onClick={() => setWeekOffset(weekOffset + 1)} className="px-2 py-1 bg-gray-200 rounded">&gt;</button>
             </div>
-            <WeekdayHeader
-              weekdays={weekdays}
-              selectedDay={selectedDay}
-              setSelectedDay={setSelectedDay}
-              selectedChore={selectedChore}
-              quickAdd={quickAdd}
-            />
-            <div className="grid grid-cols-8 gap-2 min-w-[800px]">
-              {chores.map(group => (
-                <React.Fragment key={group.group}>
-                  <div className="col-span-8 font-semibold bg-pantone564/10 p-2 text-pantone564">{group.group}</div>
+            <div className="overflow-x-auto max-h-[70vh] overflow-y-auto">
+              <WeekdayHeader
+                weekdays={weekdays}
+                selectedDay={selectedDay}
+                setSelectedDay={setSelectedDay}
+                selectedChore={selectedChore}
+                quickAdd={quickAdd}
+              />
+              <div className="grid grid-cols-8 gap-2 min-w-[800px]">
+                  {chores.map(group => (
+                    <React.Fragment key={group.group}>
+                      <div className="col-span-8 font-semibold bg-pantone564/10 p-2 text-pantone564">{group.group}</div>
                   {group.chores.map(chore => (
                     <div key={group.group + '-' + chore} className="contents">
                       <div

--- a/client/week.html
+++ b/client/week.html
@@ -26,7 +26,7 @@
       <div id="week-info" class="font-semibold"></div>
       <button id="next-week" class="px-2 py-1 bg-gray-200 rounded">&gt;</button>
     </div>
-    <div id="content" class="mb-2">Loading...</div>
+    <div id="content" class="mb-2 max-h-[70vh] overflow-y-auto">Loading...</div>
     <a href="index.html" class="bg-p604 text-black rounded px-3 py-1 no-underline">Back</a>
   </div>
   <script>


### PR DESCRIPTION
## Summary
- wrap the React weekly overview table in a fixed-height container
- add same scrolling behavior to the plain weekly overview page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68482ed961dc8331a3f67285379f1e73