### PR TITLE
Fix missing vendor libs using CDN

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -17,9 +17,9 @@
       }
     };
   </script>
-  <script src="vendor/react.development.js"></script>
-  <script src="vendor/react-dom.development.js"></script>
-  <script src="vendor/babel.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 </head>
 <body class="bg-gradient-to-br from-pantone604/10 to-pantone564/10 min-h-screen flex items-center justify-center">
   <div id="root" class="w-full"></div>


### PR DESCRIPTION
## Summary
- load React, ReactDOM and Babel from a CDN instead of local `vendor` files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68487a3d26c083319a9e611dcfd9fcb4