### PR TITLE
Add automatic logout on token expiration

### DIFF
--- a/client/all.html
+++ b/client/all.html
@@ -28,6 +28,16 @@
   </div>
   <script>
     const token = localStorage.getItem('token') || '';
+    const authFetch = async (url, options = {}) => {
+      options.headers = { ...(options.headers || {}), 'Authorization': 'Bearer ' + token };
+      const res = await fetch(url, options);
+      if (res.status === 401) {
+        localStorage.removeItem('token');
+        location.href = 'index.html';
+        return Promise.reject(new Error('Unauthorized'));
+      }
+      return res;
+    };
     let username = '';
     if (token) {
       username = JSON.parse(atob(token.split('.')[1])).username;
@@ -45,7 +55,7 @@
     }
 
     async function loadAllLogs() {
-      const res = await fetch('/api/logs/all', { headers: { 'Authorization': 'Bearer ' + token } });
+      const res = await authFetch('/api/logs/all');
       const logs = await res.json();
       const grouped = {};
       logs.forEach(l => {
@@ -78,9 +88,8 @@
             if (l.user === username) {
               il.className = 'cursor-pointer hover:line-through';
               il.addEventListener('click', async () => {
-                await fetch(`/api/logs/${l.id}`, {
-                  method: 'DELETE',
-                  headers: { 'Authorization': 'Bearer ' + token }
+                await authFetch(`/api/logs/${l.id}`, {
+                  method: 'DELETE'
                 });
                 loadAllLogs();
               });

--- a/client/index.html
+++ b/client/index.html
@@ -107,6 +107,15 @@
     }
 
     function ChoreTracker({ token, onLogout }) {
+      const authFetch = async (url, options = {}) => {
+        options.headers = { ...(options.headers || {}), 'Authorization': 'Bearer ' + token };
+        const res = await fetch(url, options);
+        if (res.status === 401) {
+          onLogout();
+          return Promise.reject(new Error('Unauthorized'));
+        }
+        return res;
+      };
       const [newChore, setNewChore] = useState('');
       const [newGroup, setNewGroup] = useState('');
       const [chores, setChores] = useState([]);
@@ -152,8 +161,8 @@
 
       async function loadData() {
         const [logsRes, topRes] = await Promise.all([
-          fetch('/api/logs/all', { headers: { 'Authorization': 'Bearer ' + token } }),
-          fetch('/api/chores/top', { headers: { 'Authorization': 'Bearer ' + token } })
+          authFetch('/api/logs/all'),
+          authFetch('/api/chores/top')
         ]);
         const logs = await logsRes.json();
         const top = await topRes.json();
@@ -195,11 +204,10 @@
         }
         const tsDate = new Date(start);
         tsDate.setDate(start.getDate() + dayIndex);
-        await fetch('/api/chores', {
+        await authFetch('/api/chores', {
           method: 'POST',
           headers: {
-            'Content-Type': 'application/json',
-            'Authorization': 'Bearer ' + token
+            'Content-Type': 'application/json'
           },
           body: JSON.stringify({ name: newChore.trim(), ts: tsDate.getTime(), group: newGroup.trim() })
         });
@@ -214,11 +222,10 @@
         const dayIndex = weekdays.indexOf(day);
         const tsDate = new Date(start);
         tsDate.setDate(start.getDate() + (dayIndex === -1 ? 0 : dayIndex));
-        await fetch('/api/chores', {
+        await authFetch('/api/chores', {
           method: 'POST',
           headers: {
-            'Content-Type': 'application/json',
-            'Authorization': 'Bearer ' + token
+            'Content-Type': 'application/json'
           },
           body: JSON.stringify({ name: choreName, ts: tsDate.getTime(), group: groupName })
         });
@@ -228,25 +235,26 @@
       }
 
       async function deleteLog(id) {
-        await fetch(`/api/logs/${id}`, {
-          method: 'DELETE',
-          headers: { 'Authorization': 'Bearer ' + token }
+        await authFetch(`/api/logs/${id}`, {
+          method: 'DELETE'
         });
         loadData();
       }
 
       useEffect(() => {
         if (!newChore.trim()) { setSuggestions([]); return; }
-        fetch('/api/chores/autocomplete?q=' + encodeURIComponent(newChore.trim()), {
-          headers: { 'Authorization': 'Bearer ' + token }
-        }).then(r => r.json()).then(setSuggestions);
+        authFetch('/api/chores/autocomplete?q=' + encodeURIComponent(newChore.trim()))
+          .then(r => r.json())
+          .then(setSuggestions)
+          .catch(() => {});
       }, [newChore]);
 
       useEffect(() => {
         if (!newGroup.trim()) { setGroupSuggestions([]); return; }
-        fetch('/api/groups/autocomplete?q=' + encodeURIComponent(newGroup.trim()), {
-          headers: { 'Authorization': 'Bearer ' + token }
-        }).then(r => r.json()).then(setGroupSuggestions);
+        authFetch('/api/groups/autocomplete?q=' + encodeURIComponent(newGroup.trim()))
+          .then(r => r.json())
+          .then(setGroupSuggestions)
+          .catch(() => {});
       }, [newGroup]);
 
       const getUsersForChoreAndDay = (chore, group, day) => {


### PR DESCRIPTION
## Summary
- add `authFetch` helper in client apps
- automatically clear the token and redirect or logout on HTTP 401

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c2adb2304833189a9befa6903123e