### PR TITLE
Move default DB file to data directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 server/db.json
+data/db.json

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ Start the container and mount a host file to persist the database:
 
 ```bash
 docker run -p 3000:3000 \
-  -v $(pwd)/db.json:/app/server/db.json \
+  -v $(pwd)/db.json:/app/data/db.json \
   choreapp
 ```
 
-The server uses `/app/server/db.json` by default. You can specify a different
+The server uses `/app/data/db.json` by default. You can specify a different
 location inside the container with the `DB_FILE` environment variable. Adjust
 the mounted path accordingly:
 

--- a/server/server.js
+++ b/server/server.js
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Low } from 'lowdb';
 import { JSONFile } from 'lowdb/node';
 import path from 'path';
+import fs from 'fs';
 import { fileURLToPath } from 'url';
 import http from 'http';
 import { WebSocketServer } from 'ws';
@@ -27,7 +28,11 @@ function broadcastUpdate() {
   });
 }
 
-const dbFile = process.env.DB_FILE || path.join(__dirname, 'db.json');
+const dbFile = process.env.DB_FILE || path.join(__dirname, '../data/db.json');
+const dbDir = path.dirname(dbFile);
+if (!fs.existsSync(dbDir)) {
+  fs.mkdirSync(dbDir, { recursive: true });
+}
 const adapter = new JSONFile(dbFile);
 const db = new Low(adapter, { users: [], chores: [], logs: [], groups: [] });
 


### PR DESCRIPTION
## Summary
- store db file in dedicated `data` directory
- ensure data directory exists on startup
- update `.gitignore`
- document new mount path in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ec73c9dd483319f7fe43d7b6c02ee