### PR TITLE
Add avatar picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ also choose the weekday before adding a chore so it is logged for that day.
 
 You can log out at any time using the **Logout** button in the app.
 
-Users can personalize their profile with an avatar. Click the **Edit** button next to your avatar to choose from a few cute emoji presets or upload your own image.
+Users can personalize their profile with an avatar. Click the **Edit** button next to your avatar to choose from a few cute emoji presets, pick from previously uploaded images, or upload your own.
 
 
 Chores can be organized into **groups**. When adding a chore you may specify a

--- a/client/index.html
+++ b/client/index.html
@@ -130,6 +130,16 @@
       const [avatar, setAvatar] = useState('');
       const builtinAvatars = { cat: '🐱', frog: '🐸', star: '⭐' };
       const [editingAvatar, setEditingAvatar] = useState(false);
+      const [storedAvatars, setStoredAvatars] = useState([]);
+
+      useEffect(() => {
+        if (editingAvatar) {
+          authFetch('/api/avatars')
+            .then(r => r.json())
+            .then(setStoredAvatars)
+            .catch(() => {});
+        }
+      }, [editingAvatar]);
 
       useEffect(() => {
         const proto = location.protocol === 'https:' ? 'wss' : 'ws';
@@ -282,6 +292,15 @@
         setEditingAvatar(false);
       }
 
+      async function selectExisting(file) {
+        const body = new URLSearchParams();
+        body.append('existing', file);
+        const res = await authFetch('/api/users/avatar', { method: 'POST', body });
+        const data = await res.json();
+        setAvatar(data.avatar);
+        setEditingAvatar(false);
+      }
+
       async function uploadAvatar(e) {
         const file = e.target.files[0];
         if (!file) return;
@@ -349,6 +368,14 @@
                   >
                     {emoji}
                   </button>
+                ))}
+                {storedAvatars.map(file => (
+                  <img
+                    key={file}
+                    src={'/avatars/' + file}
+                    className="w-12 h-12 rounded-full border cursor-pointer object-cover"
+                    onClick={() => selectExisting(file)}
+                  />
                 ))}
                 <input type="file" onChange={uploadAvatar} />
                 <button className="px-2 py-1 bg-gray-200 rounded" onClick={() => setEditingAvatar(false)}>Close</button>


### PR DESCRIPTION
## Summary
- allow choosing an existing avatar image
- expose avatar file list for clients
- show stored avatars in the profile editor
- document new avatar options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68507e6d719483319713234af90439a1