### PR TITLE
Fix selecting stored avatars

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -286,7 +286,11 @@
       async function selectBuiltin(name) {
         const body = new URLSearchParams();
         body.append('builtin', name);
-        const res = await authFetch('/api/users/avatar', { method: 'POST', body });
+        const res = await authFetch('/api/users/avatar', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body
+        });
         const data = await res.json();
         setAvatar(data.avatar);
         setEditingAvatar(false);
@@ -295,7 +299,11 @@
       async function selectExisting(file) {
         const body = new URLSearchParams();
         body.append('existing', file);
-        const res = await authFetch('/api/users/avatar', { method: 'POST', body });
+        const res = await authFetch('/api/users/avatar', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body
+        });
         const data = await res.json();
         setAvatar(data.avatar);
         setEditingAvatar(false);

--- a/server/server.js
+++ b/server/server.js
@@ -335,7 +335,7 @@ app.post('/api/users/avatar', authMiddleware, upload.single('avatar'), async (re
     return res.json({ message: 'Avatar updated', avatar: user.avatar });
   }
   if (req.body.existing) {
-    const file = path.basename(req.body.existing);
+    const file = decodeURIComponent(path.basename(req.body.existing));
     const filePath = path.join(avatarsDir, file);
     if (!filePath.startsWith(avatarsDir) || !fs.existsSync(filePath)) {
       return res.status(400).json({ error: 'Invalid file' });


### PR DESCRIPTION
## Summary
- send proper form encoding headers when updating avatar
- decode existing filenames on server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68508331b96c83319f8d022418f449b4