### PR TITLE
Fix OCR container start path

### DIFF
--- a/ocr-server/Dockerfile
+++ b/ocr-server/Dockerfile
@@ -9,4 +9,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY ocr-server ./ocr-server
 
 EXPOSE 5000
-CMD ["python3", "ocr_server.py"]
+CMD ["python3", "ocr-server/ocr_server.py"]


### PR DESCRIPTION
## Summary
- fix OCR Dockerfile CMD to use correct file path

## Testing
- `npm test`
- `flake8 ocr-server/ocr_server.py`

------
https://chatgpt.com/codex/tasks/task_e_68593eedeea48331a2b64f555d1d3af4