### PR TITLE
Allow configuring OCR server port

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,15 @@ docker run -p 3000:3000 \
   choreapp-node
 ```
 
-Run the OCR service in a separate container:
+The Node backend expects the OCR service on port `5000`. Set `OCR_PORT` when
+running both containers if you choose a different port.
+
+Run the OCR service in a separate container. It listens on port `5000` by default, but you can set a different port with the `OCR_PORT` environment variable:
 
 ```bash
 docker run -p 5000:5000 choreapp-ocr
+# or for a custom port
+docker run -p 6000:6000 -e OCR_PORT=6000 choreapp-ocr
 ```
 
 ## Admin page
@@ -81,7 +86,7 @@ and delete uploaded avatar images.
 
 ## OCR Backend
 
-An additional microservice provides optical character recognition for images of printed tables filled out by hand. It is packaged as a separate Docker image and listens on port `5000`.
+An additional microservice provides optical character recognition for images of printed tables filled out by hand. It is packaged as a separate Docker image and listens on port `5000` by default.
 
 To run the OCR service outside the container:
 
@@ -90,4 +95,4 @@ pip install -r ocr-server/requirements.txt
 python3 ocr-server/ocr_server.py
 ```
 
-Send a POST request with an image file under the `image` form field to `http://localhost:5000/api/ocr` and you will receive the recognized text lines as JSON.
+Send a POST request with an image file under the `image` form field to `http://localhost:<OCR_PORT>/api/ocr` (replace `<OCR_PORT>` with the port in use) and you will receive the recognized text lines as JSON.

--- a/node-server/server.js
+++ b/node-server/server.js
@@ -431,8 +431,9 @@ app.post('/api/ocr', memoryUpload.single('image'), async (req, res) => {
   if (!req.file) return res.status(400).json({ error: 'No file' });
   const form = new FormData();
   form.append('image', new Blob([req.file.buffer]), req.file.originalname);
+  const ocrPort = process.env.OCR_PORT || 5000;
   try {
-    const response = await fetch('http://localhost:5000/api/ocr', { method: 'POST', body: form });
+    const response = await fetch(`http://localhost:${ocrPort}/api/ocr`, { method: 'POST', body: form });
     const data = await response.json();
     res.status(response.status).json(data);
   } catch (err) {

--- a/ocr-server/ocr_server.py
+++ b/ocr-server/ocr_server.py
@@ -19,4 +19,6 @@ def ocr_image():
     return jsonify({'text': text, 'lines': lines})
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000)
+    import os
+    port = int(os.environ.get('OCR_PORT', 5000))
+    app.run(host='0.0.0.0', port=port)


### PR DESCRIPTION
## Summary
- make OCR server listen on port defined by `OCR_PORT`
- have Node backend call the OCR service using the same variable
- document the new environment variable in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859abc5a7108331afe71551d9a577cd