### PR TITLE
Improve logging for OCR service

### DIFF
--- a/node-server/server.js
+++ b/node-server/server.js
@@ -432,11 +432,14 @@ app.post('/api/ocr', memoryUpload.single('image'), async (req, res) => {
   const form = new FormData();
   form.append('image', new Blob([req.file.buffer]), req.file.originalname);
   const ocrPort = process.env.OCR_PORT || 5000;
+  console.log(`Sending OCR request to http://localhost:${ocrPort}/api/ocr`);
   try {
     const response = await fetch(`http://localhost:${ocrPort}/api/ocr`, { method: 'POST', body: form });
     const data = await response.json();
+    console.log('OCR server responded with status', response.status);
     res.status(response.status).json(data);
   } catch (err) {
+    console.error('Error contacting OCR server:', err);
     res.status(500).json({ error: 'Failed to contact OCR server' });
   }
 });
@@ -444,4 +447,11 @@ app.post('/api/ocr', memoryUpload.single('image'), async (req, res) => {
 app.use(express.static(path.join(__dirname, '../client')));
 
 const PORT = process.env.PORT || 3000;
+console.log('Configuration:');
+console.log(' PORT:', PORT);
+console.log(' DB_FILE:', dbFile);
+console.log(' OCR_PORT:', process.env.OCR_PORT || 5000);
+console.log(' ADMIN_USER:', ADMIN_USER);
+console.log(' ADMIN_PASS:', ADMIN_PASS ? '***' : '(default)');
+console.log(' SECRET set:', !!process.env.SECRET);
 server.listen(PORT, () => console.log('Server listening on', PORT));

--- a/ocr-server/ocr_server.py
+++ b/ocr-server/ocr_server.py
@@ -1,18 +1,22 @@
 from flask import Flask, request, jsonify
 import pytesseract
 from PIL import Image
+import logging
 
 app = Flask(__name__)
 
 @app.route('/api/ocr', methods=['POST'])
 def ocr_image():
     if 'image' not in request.files:
+        app.logger.warning('No image file received')
         return jsonify({'error': 'No image file'}), 400
     file = request.files['image']
     try:
         image = Image.open(file.stream)
     except Exception:
+        app.logger.warning('Invalid image file')
         return jsonify({'error': 'Invalid image'}), 400
+    app.logger.info('Running OCR on received image')
     text = pytesseract.image_to_string(image)
     # Split lines and remove empties
     lines = [line.strip() for line in text.splitlines() if line.strip()]
@@ -20,5 +24,8 @@ def ocr_image():
 
 if __name__ == '__main__':
     import os
+    logging.basicConfig(level=logging.INFO)
     port = int(os.environ.get('OCR_PORT', 5000))
+    logging.info('Starting OCR server')
+    logging.info(' OCR_PORT=%s', os.environ.get('OCR_PORT', '5000 (default)'))
     app.run(host='0.0.0.0', port=port)


### PR DESCRIPTION
## Summary
- add request and startup logs in Node server
- log OCR route requests and environment config
- log OCR server startup and request handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859bd8e6210833190aec1831d383b20