### PR TITLE
Support OCR_HOST configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,11 @@ docker run -p 3000:3000 \
   choreapp-node
 ```
 
-The Node backend expects the OCR service on port `5000`. Set `OCR_PORT` when
-running both containers if you choose a different port.
+The Node backend expects the OCR service on port `5000` and at host `localhost`
+by default. When running the OCR service in a separate container, set `OCR_HOST`
+to the OCR container's hostname or IP address and ensure both containers share a
+Docker network. Set `OCR_PORT` when running both containers if you choose a
+different port.
 
 Run the OCR service in a separate container. It listens on port `5000` by default, but you can set a different port with the `OCR_PORT` environment variable:
 

--- a/node-server/server.js
+++ b/node-server/server.js
@@ -431,10 +431,11 @@ app.post('/api/ocr', memoryUpload.single('image'), async (req, res) => {
   if (!req.file) return res.status(400).json({ error: 'No file' });
   const form = new FormData();
   form.append('image', new Blob([req.file.buffer]), req.file.originalname);
+  const ocrHost = process.env.OCR_HOST || 'localhost';
   const ocrPort = process.env.OCR_PORT || 5000;
-  console.log(`Sending OCR request to http://localhost:${ocrPort}/api/ocr`);
+  console.log(`Sending OCR request to http://${ocrHost}:${ocrPort}/api/ocr`);
   try {
-    const response = await fetch(`http://localhost:${ocrPort}/api/ocr`, { method: 'POST', body: form });
+    const response = await fetch(`http://${ocrHost}:${ocrPort}/api/ocr`, { method: 'POST', body: form });
     const data = await response.json();
     console.log('OCR server responded with status', response.status);
     res.status(response.status).json(data);
@@ -450,6 +451,7 @@ const PORT = process.env.PORT || 3000;
 console.log('Configuration:');
 console.log(' PORT:', PORT);
 console.log(' DB_FILE:', dbFile);
+console.log(' OCR_HOST:', process.env.OCR_HOST || 'localhost');
 console.log(' OCR_PORT:', process.env.OCR_PORT || 5000);
 console.log(' ADMIN_USER:', ADMIN_USER);
 console.log(' ADMIN_PASS:', ADMIN_PASS ? '***' : '(default)');


### PR DESCRIPTION
## Summary
- allow specifying OCR_HOST in the Node server
- log OCR_HOST on startup
- document OCR_HOST in Docker section of README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859c2af11b083319e18b07459212a6d