### PR TITLE
Include English and German OCR data

### DIFF
--- a/ocr-server/Dockerfile
+++ b/ocr-server/Dockerfile
@@ -1,7 +1,11 @@
 FROM python:3.12-alpine
 WORKDIR /app
 
-RUN apk add --no-cache tesseract-ocr
+RUN apk add --no-cache \
+    tesseract-ocr \
+    tesseract-ocr-data-eng \
+    tesseract-ocr-data-deu
+ENV TESSDATA_PREFIX=/usr/share/tessdata
 
 COPY ocr-server/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
## Summary
- install German and English language packs in OCR image
- set `TESSDATA_PREFIX`

## Testing
- `npm test` *(fails: No tests)*
- `docker build` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859ce52fea88331b1013a3f221a6ede