### PR TITLE
Add profile editing in main view

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -120,7 +120,7 @@
       );
     }
 
-    function ChoreTracker({ token, onLogout }) {
+    function ChoreTracker({ token, onLogout, onToken }) {
       const authFetch = async (url, options = {}) => {
         options.headers = { ...(options.headers || {}), 'Authorization': 'Bearer ' + token };
         const res = await fetch(url, options);
@@ -140,7 +140,8 @@
       const weekdays = ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'];
       const [selectedDay, setSelectedDay] = useState('');
       const [selectedChore, setSelectedChore] = useState({ name: '', group: '' });
-      const username = JSON.parse(atob(token.split('.')[1])).username;
+      const initialUsername = JSON.parse(atob(token.split('.')[1])).username;
+      const [username, setUsername] = useState(initialUsername);
       const [avatar, setAvatar] = useState('');
       const builtinAvatars = { cat: '🐱', frog: '🐸', star: '⭐' };
       const [editingAvatar, setEditingAvatar] = useState(false);
@@ -175,6 +176,21 @@
         const res = await authFetch('/api/users/me');
         const data = await res.json();
         setAvatar(data.avatar || '');
+        setUsername(data.username || initialUsername);
+      }
+
+      async function saveUsername() {
+        const res = await authFetch('/api/users/username', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ username })
+        });
+        const data = await res.json();
+        if (data.token) {
+          localStorage.setItem('token', data.token);
+          if (onToken) onToken(data.token);
+        }
+        setUsername(data.username);
       }
 
       function startOfWeek(date) {
@@ -370,13 +386,19 @@
             <h2 className="text-lg font-bold text-pantone564 mb-3">{t('title_chore_tracker')}</h2>
             <div className="flex gap-2 flex-wrap items-center">
               {avatar && avatar.includes('.') ? (
-                <img src={'/avatars/' + avatar} className="w-10 h-10 rounded-full border" />
+                <img src={'/avatars/' + avatar} className="w-16 h-16 rounded-full border object-cover" />
               ) : (
-                <div className="w-10 h-10 rounded-full border flex items-center justify-center text-xl">
+                <div className="w-16 h-16 rounded-full border flex items-center justify-center text-2xl">
                   {builtinAvatars[avatar || 'star']}
                 </div>
               )}
               <button className="bg-gray-200 px-2 py-1 rounded" onClick={() => setEditingAvatar(!editingAvatar)}>{t('edit')}</button>
+              <input
+                className="border p-1 rounded"
+                value={username}
+                onChange={e => setUsername(e.target.value)}
+              />
+              <button className="bg-pantone564 text-white px-2 py-1 rounded" onClick={saveUsername}>{t('save')}</button>
               <input
                 list="chore-suggestions"
                 className="flex-1 border p-2 rounded"
@@ -519,7 +541,7 @@
       const [token, setToken] = useState(localStorage.getItem('token') || '');
       const logout = () => { localStorage.removeItem('token'); setToken(''); };
 
-      return token ? <ChoreTracker token={token} onLogout={logout} /> : <Auth onLogin={setToken} />;
+      return token ? <ChoreTracker token={token} onLogout={logout} onToken={setToken} /> : <Auth onLogin={setToken} />;
     }
 
     ReactDOM.createRoot(document.getElementById('root')).render(<App />);


### PR DESCRIPTION
## Summary
- allow changing username via API
- display a larger avatar and username field in the main view
- keep JWT token in sync when username is updated

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866505708a08331a21b85126770bdd0