### PR TITLE
Add unified profile editor with pen icon

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -144,19 +144,19 @@
       const [username, setUsername] = useState(initialUsername);
       const [avatar, setAvatar] = useState('');
       const builtinAvatars = { cat: '🐱', frog: '🐸', star: '⭐' };
-      const [editingAvatar, setEditingAvatar] = useState(false);
+      const [editingProfile, setEditingProfile] = useState(false);
       const [storedAvatars, setStoredAvatars] = useState([]);
       const [weeklyGoals, setWeeklyGoals] = useState([]);
       const [unfinishedGoals, setUnfinishedGoals] = useState(new Set());
 
       useEffect(() => {
-        if (editingAvatar) {
+        if (editingProfile) {
           authFetch('/api/avatars')
             .then(r => r.json())
             .then(setStoredAvatars)
             .catch(() => {});
         }
-      }, [editingAvatar]);
+      }, [editingProfile]);
 
       useEffect(() => {
         const proto = location.protocol === 'https:' ? 'wss' : 'ws';
@@ -392,13 +392,8 @@
                   {builtinAvatars[avatar || 'star']}
                 </div>
               )}
-              <button className="bg-gray-200 px-2 py-1 rounded" onClick={() => setEditingAvatar(!editingAvatar)}>{t('edit')}</button>
-              <input
-                className="border p-1 rounded"
-                value={username}
-                onChange={e => setUsername(e.target.value)}
-              />
-              <button className="bg-pantone564 text-white px-2 py-1 rounded" onClick={saveUsername}>{t('save')}</button>
+              <span className="font-medium">{username}</span>
+              <button className="px-1" onClick={() => setEditingProfile(true)} title={t('edit')}>✏️</button>
               <input
                 list="chore-suggestions"
                 className="flex-1 border p-2 rounded"
@@ -432,8 +427,24 @@
                 <option value="de">Deutsch</option>
               </select>
             </div>
-            {editingAvatar && (
+            {editingProfile && (
               <div className="mt-2 flex gap-2 items-center">
+                <div className="flex items-center gap-2">
+                  {avatar && avatar.includes('.') ? (
+                    <img src={'/avatars/' + avatar} className="w-16 h-16 rounded-full border object-cover" />
+                  ) : (
+                    <div className="w-16 h-16 rounded-full border flex items-center justify-center text-2xl">
+                      {builtinAvatars[avatar || 'star']}
+                    </div>
+                  )}
+                  <input
+                    className="border p-1 rounded"
+                    value={username}
+                    onChange={e => setUsername(e.target.value)}
+                  />
+                  <button className="bg-pantone564 text-white px-2 py-1 rounded" onClick={async ()=>{await saveUsername();setEditingProfile(false);}}>{t('save')}</button>
+                  <button className="px-2 py-1 bg-gray-200 rounded" onClick={() => setEditingProfile(false)}>{t('close')}</button>
+                </div>
                 {Object.entries(builtinAvatars).map(([name, emoji]) => (
                   <button
                     key={name}
@@ -452,7 +463,6 @@
                   />
                 ))}
                 <input type="file" accept="image/*" onChange={uploadAvatar} />
-                <button className="px-2 py-1 bg-gray-200 rounded" onClick={() => setEditingAvatar(false)}>{t('close')}</button>
               </div>
             )}
           </div>

--- a/client/lang/de.json
+++ b/client/lang/de.json
@@ -13,6 +13,7 @@
   "weekly_goals": "Wöchentliche Ziele",
   "logout": "Abmelden",
   "edit": "Bearbeiten",
+  "save": "Speichern",
   "close": "Schließen",
   "goal_name": "Zielname",
   "group": "Gruppe",

--- a/client/lang/en.json
+++ b/client/lang/en.json
@@ -13,6 +13,7 @@
   "weekly_goals": "Weekly Goals",
   "logout": "Logout",
   "edit": "Edit",
+  "save": "Save",
   "close": "Close",
   "goal_name": "Goal name",
   "group": "Group",

--- a/client/lang/es.json
+++ b/client/lang/es.json
@@ -13,6 +13,7 @@
   "weekly_goals": "Metas semanales",
   "logout": "Cerrar sesión",
   "edit": "Editar",
+  "save": "Guardar",
   "close": "Cerrar",
   "goal_name": "Nombre de la meta",
   "group": "Grupo",


### PR DESCRIPTION
## Summary
- make avatar and username editable in a single profile editor
- open the editor with a small pen icon
- add missing `save` translation in all languages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68697f1868c88331b6bf25ffcd4b732b