### PR TITLE
Move language selector to profile editor

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -421,11 +421,6 @@
               <a href="goals.html" className="bg-gray-300 hover:bg-gray-400 text-black px-3 py-2 rounded no-underline">{t('weekly_goals')}</a>
               <a href="ocr.html" className="bg-gray-300 hover:bg-gray-400 text-black px-3 py-2 rounded no-underline">{t('ocr_page')}</a>
               <button className="bg-gray-300 hover:bg-gray-400 text-black px-3 py-2 rounded" onClick={onLogout}>{t('logout')}</button>
-              <select value={window.i18n.language} onChange={e => loadLanguage(e.target.value).then(()=>{window.location.reload();})} className="border p-1 rounded">
-                <option value="en">English</option>
-                <option value="es">Español</option>
-                <option value="de">Deutsch</option>
-              </select>
             </div>
             {editingProfile && (
               <div className="mt-2 flex gap-2 items-center">
@@ -442,8 +437,14 @@
                     value={username}
                     onChange={e => setUsername(e.target.value)}
                   />
-                  <button className="bg-pantone564 text-white px-2 py-1 rounded" onClick={async ()=>{await saveUsername();setEditingProfile(false);}}>{t('save')}</button>
-                  <button className="px-2 py-1 bg-gray-200 rounded" onClick={() => setEditingProfile(false)}>{t('close')}</button>
+                    <button className="bg-pantone564 text-white px-2 py-1 rounded" onClick={async ()=>{await saveUsername();setEditingProfile(false);}}>{t('save')}</button>
+                    <button className="px-2 py-1 bg-gray-200 rounded" onClick={() => setEditingProfile(false)}>{t('close')}</button>
+                    <label className="ml-2 mr-1">{t('language')}:</label>
+                    <select value={window.i18n.language} onChange={e => loadLanguage(e.target.value).then(()=>{window.location.reload();})} className="border p-1 rounded">
+                      <option value="en">English</option>
+                      <option value="es">Español</option>
+                      <option value="de">Deutsch</option>
+                    </select>
                 </div>
                 {Object.entries(builtinAvatars).map(([name, emoji]) => (
                   <button


### PR DESCRIPTION
## Summary
- tweak index.html to only show language selector when editing the profile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869825476748331b390d198456ba0e7