### PR TITLE
Fix OCR Docker build on Python 3.12

### DIFF
--- a/ocr-server/Dockerfile
+++ b/ocr-server/Dockerfile
@@ -1,11 +1,13 @@
-FROM python:3.12-alpine
+FROM python:3.12-slim
 WORKDIR /app
 
-RUN apk add --no-cache \
-    tesseract-ocr \
-    tesseract-ocr-data-eng \
-    tesseract-ocr-data-deu
-ENV TESSDATA_PREFIX=/usr/share/tessdata
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        tesseract-ocr \
+        tesseract-ocr-eng \
+        tesseract-ocr-deu && \
+    rm -rf /var/lib/apt/lists/*
+ENV TESSDATA_PREFIX=/usr/share/tesseract-ocr/5/tessdata
 
 COPY ocr-server/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
## Summary
- update OCR Dockerfile to use the Debian-based slim Python image
- install tesseract with apt so OpenCV wheels install cleanly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d9bd07a8c8331b68603b8e9e48dca